### PR TITLE
Correct validation on existing dependencies

### DIFF
--- a/maven/org.amelia.dsl.lib/src/main/java/org/amelia/dsl/lib/descriptors/CommandDescriptor.java
+++ b/maven/org.amelia.dsl.lib/src/main/java/org/amelia/dsl/lib/descriptors/CommandDescriptor.java
@@ -244,7 +244,7 @@ public class CommandDescriptor extends Observable {
 		for (CommandDescriptor descriptor : dependencies) {
 			if (descriptor.equals(this))
 				throw new IllegalArgumentException("A command cannot depend on itself");
-			if (this.dependencies.contains(dependencies)) {
+			if (this.dependencies.contains(descriptor)) {
 				all = false;
 				continue;
 			}


### PR DESCRIPTION
The validation of duplicate dependencies was wrong, as it was validating against the wrong object.
